### PR TITLE
update to latest model options api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.1.0'
 
     // Tensor/IO Dependency
-    implementation 'com.github.doc-ai:tensorio-android:0.9.4'
+    implementation 'com.github.doc-ai:tensorio-android:1bba798eb72506a29f34284584ffb2d081610955'
 
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'


### PR DESCRIPTION
turns out selecting the gpu configuration wasn't actually using the gpu! gpu configuration now cuts latency in half (!) on my pixel test device. fix is in https://github.com/doc-ai/tensorio-android/commit/1bba798eb72506a29f34284584ffb2d081610955 but shows up here.