### PR TITLE
Separate handlers for classification results

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.google.android.material:material:1.1.0'
-    implementation 'com.github.doc-ai:tensorio-android:0.9.5'
+    implementation 'com.github.doc-ai:tensorio-android:044cb7ccf64559e47effb280d0060735c420d953'
 
     testImplementation 'junit:junit:4.13'
 

--- a/app/src/main/assets/mobilenet_V1_0.25_128.tiobundle/model.json
+++ b/app/src/main/assets/mobilenet_V1_0.25_128.tiobundle/model.json
@@ -7,6 +7,7 @@
   "license": "Apache License. Version 2.0 http://www.apache.org/licenses/LICENSE-2.0",
   "model": {
     "file": "mobilenet_v1_0.25_128.tflite",
+    "type": "image.classification.imagenet",
     "quantized": false
   },
   "inputs": [

--- a/app/src/main/assets/mobilenet_V1_0.25_160.tiobundle/model.json
+++ b/app/src/main/assets/mobilenet_V1_0.25_160.tiobundle/model.json
@@ -7,6 +7,7 @@
   "license": "Apache License. Version 2.0 http://www.apache.org/licenses/LICENSE-2.0",
   "model": {
     "file": "mobilenet_v1_0.25_160.tflite",
+    "type": "image.classification.imagenet",
     "quantized": false
   },
   "inputs": [

--- a/app/src/main/assets/mobilenet_V1_0.25_192.tiobundle/model.json
+++ b/app/src/main/assets/mobilenet_V1_0.25_192.tiobundle/model.json
@@ -7,6 +7,7 @@
   "license": "Apache License. Version 2.0 http://www.apache.org/licenses/LICENSE-2.0",
   "model": {
     "file": "mobilenet_v1_0.25_192.tflite",
+    "type": "image.classification.imagenet",
     "quantized": false
   },
   "inputs": [

--- a/app/src/main/assets/mobilenet_v1_1.0_224_quant.tiobundle/model.json
+++ b/app/src/main/assets/mobilenet_v1_1.0_224_quant.tiobundle/model.json
@@ -7,8 +7,8 @@
 	"license": "Apache License. Version 2.0 http://www.apache.org/licenses/LICENSE-2.0",
 	"model": {
 		"file": "mobilenet_v1_1.0_224_quant.tflite",
-		"quantized": true,
-		"type": "image.classification.imagenet"
+		"type": "image.classification.imagenet",
+		"quantized": true
 	},
 	"inputs": [
 		{

--- a/app/src/main/assets/mobilenet_v2_1.4_224.tiobundle/model.json
+++ b/app/src/main/assets/mobilenet_v2_1.4_224.tiobundle/model.json
@@ -7,6 +7,7 @@
   "license": "Apache License. Version 2.0 http://www.apache.org/licenses/LICENSE-2.0",
   "model": {
     "file": "mobilenet_v2_1.4_224.tflite",
+    "type": "image.classification.imagenet",
     "quantized": false
   },
   "inputs": [

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -119,9 +119,9 @@ class MainActivity : AppCompatActivity() {
             val modelRunner = ModelRunner((model as TIOTFLiteModel), modelRunnerExceptionHandler)
 
             viewModel.modelRunner = modelRunner
-            viewModel.modelRunner.setDevice(ModelRunner.deviceFromString(device), null)
-            viewModel.modelRunner.setNumThreads(numThreads, null)
-            viewModel.modelRunner.setUse16Bit(use16Bit, null)
+            viewModel.modelRunner.setDevice(ModelRunner.deviceFromString(device))
+            viewModel.modelRunner.setNumThreads(numThreads)
+            viewModel.modelRunner.setUse16Bit(use16Bit)
 
             model.load()
         } catch(e: Exception) {

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -52,6 +52,8 @@ private const val READ_EXTERNAL_STORAGE_REQUEST_CODE = 123
 private const val REQUEST_CODE_PICK_IMAGE = 1
 private const val REQUEST_IMAGE_CAPTURE = 2
 
+// TODO: Wrap any call to set the device or change the model in a try block
+
 class MainActivity : AppCompatActivity() {
 
     private val numThreadsOptions = arrayOf(1, 2, 4, 8)

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -2,6 +2,7 @@ package ai.doc.netrunner
 
 import ai.doc.netrunner.view.*
 import ai.doc.netrunner.MainViewModel.Tab
+import ai.doc.netrunner.outputhandler.OutputHandlerManager
 
 import ai.doc.tensorio.TIOModel.TIOModelBundleException
 import ai.doc.tensorio.TIOModel.TIOModelBundleManager
@@ -77,6 +78,8 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        OutputHandlerManager.registerHandlers()
 
         // Acquire Saved Settings
 

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.core.content.FileProvider
 import androidx.core.content.edit
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 
 import com.google.android.material.navigation.NavigationView
@@ -95,13 +96,14 @@ class MainActivity : AppCompatActivity() {
         try {
             val bundle = viewModel.manager.bundleWithId(selectedModel)
             val model = bundle.newModel()
-            model.load()
 
             val modelRunner = ModelRunner((model as TIOTFLiteModel))
             viewModel.modelRunner = modelRunner
             viewModel.modelRunner.device = ModelRunner.deviceFromString(device)
             viewModel.modelRunner.numThreads = numThreads
             viewModel.modelRunner.use16Bit = use16Bit
+
+            model.load()
         } catch (e: IOException) {
             e.printStackTrace()
         } catch (e: TIOModelException) {
@@ -232,6 +234,11 @@ class MainActivity : AppCompatActivity() {
                     val model = selectedBundle.newModel() as TIOTFLiteModel
                     prefs.edit(true) { putString(getString(R.string.prefs_selected_model), selectedModelId) }
                     viewModel.modelRunner.switchModel(model)
+
+                    (supportFragmentManager.findFragmentById(R.id.container) as ModelRunnerWatcher)?.let {
+                        it.modelDidChange()
+                    }
+
                 } catch (e: TIOModelBundleException) {
                     e.printStackTrace()
                 } catch (e: TIOModelException) {
@@ -384,7 +391,7 @@ class MainActivity : AppCompatActivity() {
         val fragment = when (tab) {
             Tab.LiveVideo -> LiveCameraClassificationFragment()
             Tab.SinglePhoto -> SingleImageClassificationFragment()
-        }
+        } as Fragment
 
         supportFragmentManager.beginTransaction().replace(R.id.container, fragment).commit()
     }

--- a/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
+++ b/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
@@ -16,6 +16,10 @@ private const val HANDLE_THREAD_NAME = "ai.doc.netrunner.model-runner"
 private typealias Listener = (Map<String,Any>, Long) -> Unit
 private typealias BitmapProvider = () -> Bitmap?
 
+interface ModelRunnerWatcher {
+    fun modelDidChange()
+}
+
 /**
  * The ModelRunner is used to configure a model and to perform continuous or one-off inference
  * with a model.
@@ -200,6 +204,14 @@ class ModelRunner(model: TIOTFLiteModel) {
     fun stopStreamingInference() {
         backgroundHandler.post {
             running = false
+        }
+    }
+
+    /** Waits for the background handler to finish processing before calling lambda */
+
+    fun wait(lambda: ()->Unit) {
+        backgroundHandler.post {
+            lambda()
         }
     }
 }

--- a/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
+++ b/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
@@ -121,24 +121,24 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
 
     // Set Configuration with Callback
 
-    fun setNumThreads(value: Int, callback: ModelRunnerCallback?) {
+    fun setNumThreads(value: Int, callback: ModelRunnerCallback? = null) {
         backgroundHandler.post { numThreads = value }
         backgroundHandler.post(callback)
     }
 
-    fun setUse16Bit(value: Boolean, callback: ModelRunnerCallback?) {
+    fun setUse16Bit(value: Boolean, callback: ModelRunnerCallback? = null) {
         backgroundHandler.post { use16Bit = value }
         backgroundHandler.post(callback)
     }
 
-    fun setDevice(value: Device, callback: ModelRunnerCallback?) {
+    fun setDevice(value: Device, callback: ModelRunnerCallback? = null) {
         backgroundHandler.post { device = value }
         backgroundHandler.post(callback)
     }
 
     /** Changes the model and uses current settings, falls back to previous model if fails */
 
-    fun switchModel(model: TIOTFLiteModel, callback: ModelRunnerCallback?) {
+    fun switchModel(model: TIOTFLiteModel, callback: ModelRunnerCallback? = null) {
         val previousModel = this.model
 
         fun doSwitch(model: TIOTFLiteModel) {

--- a/app/src/main/java/ai/doc/netrunner/outputhandler/DefaultOutputHandler.kt
+++ b/app/src/main/java/ai/doc/netrunner/outputhandler/DefaultOutputHandler.kt
@@ -1,0 +1,68 @@
+package ai.doc.netrunner.outputhandler
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import ai.doc.netrunner.R
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ * Use the [DefaultOutputHandler.newInstance] factory method to
+ * create an instance of this fragment.
+ */
+
+class DefaultOutputHandler : Fragment(), OutputHandler {
+    // TODO: Rename and change types of parameters
+    private var param1: String? = null
+    private var param2: String? = null
+
+    companion object {
+        /**
+         * Use this factory method to create a new instance of
+         * this fragment using the provided parameters.
+         *
+         * @param param1 Parameter 1.
+         * @param param2 Parameter 2.
+         * @return A new instance of fragment DefaultOutputHandler.
+         */
+        // TODO: Rename and change types and number of parameters
+        @JvmStatic
+        fun newInstance(param1: String, param2: String) =
+                DefaultOutputHandler().apply {
+                    arguments = Bundle().apply {
+                        putString(ARG_PARAM1, param1)
+                        putString(ARG_PARAM2, param2)
+                    }
+                }
+    }
+
+    override var output: Map<String, Any>? = null
+        set(value) {
+            processOutput(value)
+            field = value
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            param1 = it.getString(ARG_PARAM1)
+            param2 = it.getString(ARG_PARAM2)
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_default_output_handler, container, false)
+    }
+
+    private fun processOutput(output: Map<String, Any>?) {
+
+    }
+}

--- a/app/src/main/java/ai/doc/netrunner/outputhandler/ImageNetClassificationOutputHandler.kt
+++ b/app/src/main/java/ai/doc/netrunner/outputhandler/ImageNetClassificationOutputHandler.kt
@@ -21,6 +21,10 @@ private const val SMOOTHING_TOP_N_COUNT = 5
 
 class MobileNetClassificationOutputHandler : Fragment(), OutputHandler {
 
+    companion object {
+        val type = "image.classification.imagenet"
+    }
+
     private lateinit var predictionTextView: TextView
 
     override var output: Map<String, Any>? = null

--- a/app/src/main/java/ai/doc/netrunner/outputhandler/ImageNetClassificationOutputHandler.kt
+++ b/app/src/main/java/ai/doc/netrunner/outputhandler/ImageNetClassificationOutputHandler.kt
@@ -53,6 +53,7 @@ class MobileNetClassificationOutputHandler : Fragment(), OutputHandler {
         output?.let {
             val classification = it["classification"] as Map<String, Float>
             val top5 = TIOClassificationHelper.topN(classification, CLASSIFICATION_TOP_N_COUNT)
+            if (previousTop5.size == 0) { previousTop5 = top5 as ArrayList<Map.Entry<String, Float>> }
             val top5smoothed = TIOClassificationHelper.smoothClassification(previousTop5, top5, SMOOTHING_DECAY, SMOOTHING_THRESHOLD)
             val top5ordered = top5smoothed.take(SMOOTHING_TOP_N_COUNT).sortedWith(compareBy { it.value }).reversed()
             val top5formatted = formattedResults(top5ordered)

--- a/app/src/main/java/ai/doc/netrunner/outputhandler/ImageNetClassificationOutputHandler.kt
+++ b/app/src/main/java/ai/doc/netrunner/outputhandler/ImageNetClassificationOutputHandler.kt
@@ -51,7 +51,7 @@ class MobileNetClassificationOutputHandler : Fragment(), OutputHandler {
 
     private fun processOutput(output: Map<String, Any>?) {
         output?.let {
-            val classification = it["classification"] as? Map<String, Float>
+            val classification = it["classification"] as Map<String, Float>
             val top5 = TIOClassificationHelper.topN(classification, CLASSIFICATION_TOP_N_COUNT)
             val top5smoothed = TIOClassificationHelper.smoothClassification(previousTop5, top5, SMOOTHING_DECAY, SMOOTHING_THRESHOLD)
             val top5ordered = top5smoothed.take(SMOOTHING_TOP_N_COUNT).sortedWith(compareBy { it.value }).reversed()

--- a/app/src/main/java/ai/doc/netrunner/outputhandler/ImageNetClassificationOutputHandler.kt
+++ b/app/src/main/java/ai/doc/netrunner/outputhandler/ImageNetClassificationOutputHandler.kt
@@ -1,0 +1,76 @@
+package ai.doc.netrunner.outputhandler
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import ai.doc.netrunner.R
+import ai.doc.tensorio.TIOUtilities.TIOClassificationHelper
+import android.widget.TextView
+
+private const val CLASSIFICATION_TOP_N_COUNT = 3
+private const val SMOOTHING_DECAY = 0.7f
+private const val SMOOTHING_THRESHOLD = 0.02f
+private const val SMOOTHING_TOP_N_COUNT = 5
+
+/**
+ * A simple [Fragment] subclass.
+ * Displays the results of an ImageNet Classification model
+ */
+
+class MobileNetClassificationOutputHandler : Fragment(), OutputHandler {
+
+    private lateinit var predictionTextView: TextView
+
+    override var output: Map<String, Any>? = null
+        set(value) {
+            processOutput(value)
+            field = value
+        }
+
+    // View Management
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_image_net_classification_output_handler, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        predictionTextView = view.findViewById(R.id.predictions)
+    }
+
+    // Output Processing
+
+    var previousTop5 = ArrayList<Map.Entry<String,Float>>()
+
+    private fun processOutput(output: Map<String, Any>?) {
+        output?.let {
+            val classification = it["classification"] as? Map<String, Float>
+            val top5 = TIOClassificationHelper.topN(classification, CLASSIFICATION_TOP_N_COUNT)
+            val top5smoothed = TIOClassificationHelper.smoothClassification(previousTop5, top5, SMOOTHING_DECAY, SMOOTHING_THRESHOLD)
+            val top5ordered = top5smoothed.take(SMOOTHING_TOP_N_COUNT).sortedWith(compareBy { it.value }).reversed()
+            val top5formatted = formattedResults(top5ordered)
+
+            predictionTextView.text = top5formatted
+            previousTop5 = top5smoothed as ArrayList<Map.Entry<String, Float>>
+        }
+    }
+
+    private fun formattedResults(results: List<Map.Entry<String, Float>>): String {
+        val b = StringBuilder()
+        for ((key, value) in results) {
+            b.append(key)
+            b.append(": ")
+            b.append(String.format("%.2f", value))
+            b.append("\n")
+        }
+
+        if (b.isNotEmpty()) {
+            b.setLength(b.length - 1)
+        }
+
+        return b.toString()
+    }
+}

--- a/app/src/main/java/ai/doc/netrunner/outputhandler/OutputHandler.kt
+++ b/app/src/main/java/ai/doc/netrunner/outputhandler/OutputHandler.kt
@@ -1,0 +1,5 @@
+package ai.doc.netrunner.outputhandler
+
+interface OutputHandler {
+    var output: Map<String, Any>?
+}

--- a/app/src/main/java/ai/doc/netrunner/outputhandler/OutputHandlerManager.kt
+++ b/app/src/main/java/ai/doc/netrunner/outputhandler/OutputHandlerManager.kt
@@ -1,0 +1,35 @@
+package ai.doc.netrunner.outputhandler
+
+object OutputHandlerManager {
+
+    // Add Your Custom Handlers Here
+    // Custom handler must extend [Fragment] and conform to [OutputHandler]
+
+    fun registerHandlers() {
+        registerHandler(DefaultOutputHandler.type, DefaultOutputHandler::class.java)
+        registerHandler(MobileNetClassificationOutputHandler.type, MobileNetClassificationOutputHandler::class.java)
+    }
+
+    // Retrieve Handler
+
+    fun handlerForType(type: String?): Class<out OutputHandler> {
+        if (type == null) {
+            return DefaultOutputHandler::class.java
+        }
+
+        handlers[type]?.let {
+            return it
+        }
+
+        return DefaultOutputHandler::class.java
+    }
+
+    // Private
+
+    private val handlers: MutableMap<String, Class<out OutputHandler>> = HashMap()
+
+    private fun registerHandler(type: String, handler: Class<out OutputHandler>) {
+        handlers.put(type, handler)
+    }
+
+}

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraFragment.kt
@@ -254,7 +254,7 @@ open class LiveCameraFragment : Fragment(), OnRequestPermissionsResultCallback {
         textureView = view.findViewById(R.id.texture)
     }
 
-    //beginRegion Lifecycle
+    //region Lifecycle
 
     override fun onResume() {
         super.onResume()
@@ -276,7 +276,7 @@ open class LiveCameraFragment : Fragment(), OnRequestPermissionsResultCallback {
         super.onPause()
     }
 
-    //endRegion
+    //endregion
 
     /**
      * Sets up member variables related to camera.

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
@@ -2,8 +2,8 @@ package ai.doc.netrunner.view
 
 import ai.doc.netrunner.MainViewModel
 import ai.doc.netrunner.R
-import ai.doc.netrunner.outputhandler.MobileNetClassificationOutputHandler
 import ai.doc.netrunner.outputhandler.OutputHandler
+import ai.doc.netrunner.outputhandler.OutputHandlerManager
 
 import android.os.Bundle
 import android.os.Handler
@@ -42,7 +42,7 @@ class LiveCameraClassificationFragment : LiveCameraFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // TODO: Assumes classification model (#24)
-        val outputHandler = MobileNetClassificationOutputHandler()
+        val outputHandler = OutputHandlerManager.handlerForType("image.classification.imagenet").newInstance() as Fragment
         childFragmentManager.beginTransaction().replace(R.id.outputContainer, outputHandler).commit()
 
         textureView = view.findViewById(R.id.texture)

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
@@ -41,8 +41,7 @@ class LiveCameraClassificationFragment : LiveCameraFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // TODO: Assumes classification model (#24)
-        val outputHandler = OutputHandlerManager.handlerForType("image.classification.imagenet").newInstance() as Fragment
+        val outputHandler = OutputHandlerManager.handlerForType(viewModel.modelRunner.model.type).newInstance() as Fragment
         childFragmentManager.beginTransaction().replace(R.id.outputContainer, outputHandler).commit()
 
         textureView = view.findViewById(R.id.texture)

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
@@ -57,12 +57,18 @@ class LiveCameraClassificationFragment : LiveCameraFragment(), ModelRunnerWatche
     /** Replaces the output handler but waits for the model runner to finish **/
 
     override fun modelDidChange() {
-        stopClassification()
         viewModel.modelRunner.wait {
             Handler(Looper.getMainLooper()).post(Runnable {
                 loadFragmentForModel(viewModel.modelRunner.model)
             })
         }
+    }
+
+    override fun stopRunning() {
+        stopClassification()
+    }
+
+    override fun startRunning() {
         startClassification()
     }
 

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
@@ -72,7 +72,7 @@ class LiveCameraClassificationFragment : LiveCameraFragment(), ModelRunnerWatche
         startClassification()
     }
 
-    //beginRegion Lifecycle
+    //region Lifecycle
 
     override fun onResume() {
         super.onResume()
@@ -85,7 +85,7 @@ class LiveCameraClassificationFragment : LiveCameraFragment(), ModelRunnerWatche
         super.onPause()
     }
 
-    //endRegion
+    //endregion
 
     private fun startClassification() {
         viewModel.modelRunner.startStreamingInference( {

--- a/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
@@ -70,6 +70,14 @@ class SingleImageClassificationFragment : Fragment(), ModelRunnerWatcher {
         }
     }
 
+    override fun stopRunning() {
+
+    }
+
+    override fun startRunning() {
+
+    }
+
     /** Executes inference on the provided bitmap */
 
     private fun doBitmap(bitmap: Bitmap) {

--- a/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
@@ -38,8 +38,7 @@ class SingleImageClassificationFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // TODO: Assumes classification model (#24)
-        val outputHandler = OutputHandlerManager.handlerForType("image.classification.imagenet").newInstance() as Fragment
+        val outputHandler = OutputHandlerManager.handlerForType(viewModel.modelRunner.model.type).newInstance() as Fragment
         childFragmentManager.beginTransaction().replace(R.id.outputContainer, outputHandler).commit()
 
         imageView = view.findViewById(R.id.imageview)

--- a/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
@@ -2,8 +2,8 @@ package ai.doc.netrunner.view
 
 import ai.doc.netrunner.MainViewModel
 import ai.doc.netrunner.R
-import ai.doc.netrunner.outputhandler.MobileNetClassificationOutputHandler
 import ai.doc.netrunner.outputhandler.OutputHandler
+import ai.doc.netrunner.outputhandler.OutputHandlerManager
 
 import android.graphics.Bitmap
 import android.os.Bundle
@@ -39,7 +39,7 @@ class SingleImageClassificationFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // TODO: Assumes classification model (#24)
-        val outputHandler = MobileNetClassificationOutputHandler()
+        val outputHandler = OutputHandlerManager.handlerForType("image.classification.imagenet").newInstance() as Fragment
         childFragmentManager.beginTransaction().replace(R.id.outputContainer, outputHandler).commit()
 
         imageView = view.findViewById(R.id.imageview)

--- a/app/src/main/res/layout/fragment_default_output_handler.xml
+++ b/app/src/main/res/layout/fragment_default_output_handler.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_weight="1"
+    tools:context=".outputhandler.DefaultOutputHandler">
+
+    <TextView
+        android:id="@+id/predictions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_tiny"
+        android:textColor="@color/black"
+        android:bufferType="spannable"
+        android:textSize="@dimen/font_size_l" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_image_net_classification_output_handler.xml
+++ b/app/src/main/res/layout/fragment_image_net_classification_output_handler.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_weight="1"
+    tools:context=".outputhandler.MobileNetClassificationOutputHandler">
+
+    <TextView
+        android:id="@+id/predictions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_tiny"
+        android:textColor="@color/black"
+        android:bufferType="spannable"
+        android:textSize="@dimen/font_size_l" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_live_camera_tab.xml
+++ b/app/src/main/res/layout/fragment_live_camera_tab.xml
@@ -24,15 +24,12 @@
         android:orientation="horizontal"
         android:layout_alignParentBottom="true">
 
-        <TextView
-            android:id="@+id/predictions"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+        <FrameLayout
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:layout_margin="@dimen/margin_tiny"
-            android:textColor="@color/black"
-            android:bufferType="spannable"
-            android:textSize="@dimen/font_size_l" />
+            android:id="@+id/outputContainer" />
 
         <TextView
             android:id="@+id/latency"

--- a/app/src/main/res/layout/fragment_single_image_tab.xml
+++ b/app/src/main/res/layout/fragment_single_image_tab.xml
@@ -30,26 +30,22 @@
         android:layout_marginRight="@dimen/margin_predictions_layout"
         android:layout_marginTop="@dimen/margin_predictions_layout"
         android:layout_marginBottom="@dimen/margin_predictions_layout"
+        android:padding="@dimen/padding_predictions_layout"
         android:background="@drawable/rounded_rectangle"
         android:orientation="horizontal">
 
-        <TextView
-            android:id="@+id/predictions"
-            android:layout_width="0dp"
+        <FrameLayout
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/margin_tiny"
             android:layout_weight="1"
-            android:bufferType="spannable"
-            android:padding="@dimen/padding_extra"
-            android:textColor="@color/black"
-            android:textSize="@dimen/font_size_l" />
+            android:layout_margin="@dimen/margin_tiny"
+            android:id="@+id/outputContainer" />
 
         <TextView
             android:id="@+id/latency"
+            android:layout_marginRight="@dimen/margin_tiny"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_tiny"
-            android:padding="@dimen/padding_extra"
             android:textColor="@color/black"
             android:textSize="@dimen/font_size_default" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,19 @@
 
     <string name="prefs_default_selected_model">Mobilenet_V2_1.0_224</string>
     <string name="prefs_default_device">CPU</string>
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
+
+    <string name="unable_to_load_model_dialog_title">Unable to load model</string>
+    <string name="unable_to_load_model_dialog_message">There was a problem loading this model, please try another one</string>
+
+    <string name="modelrunner_initfail_dialog_title">Unable to load model</string>
+    <string name="modelrunner_initfail_dialog_message">There was a problem initializing the previous model, falling back to default model and settings</string>
+
+    <string name="modelrunner_exception_dialog_title">Unable to update settings</string>
+    <string name="modelrunner_exception_run_inference_dialog_title">Unable to run the model</string>
+    <string name="modelrunner_exception_unknown_dialog_title">"An unkown problem occurred"</string>
+
+    <string name="modelrunner_exeption_gpu">GPU not supported in this build, falling back</string>
+    <string name="modelrunner_exception_run_inference">There was a problem executing inference with this model, falling back to default model and settings</string>
+    <string name="modelrunner_exception_load_model">This was a problem loading the model with these settings, falling back to previous model or settings"</string>
+    <string name="modelrunner_exception_unknown">Net Runner encountered an unknown problem, falling back to previous model or settings"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,6 @@
 
     <string name="prefs_default_selected_model">Mobilenet_V2_1.0_224</string>
     <string name="prefs_default_device">CPU</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
- Originally separate handlers for classification results: https://github.com/doc-ai/net-runner-android/issues/24
- Required sending more information to tab fragments: https://github.com/doc-ai/net-runner-android/issues/49
- And exposed GPU delegate crashes with our own models: https://github.com/doc-ai/net-runner-android/issues/51

Which then lead to a major overhaul of exception handling on background threads.

Will be nice to simply all that code and clean up with CameraView, but I think that comes in another release (https://github.com/doc-ai/net-runner-android/issues/53)