### PR TITLE
Dev locks not threads

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -120,9 +120,9 @@ class MainActivity : AppCompatActivity() {
             val modelRunner = ModelRunner((model as TIOTFLiteModel), modelRunnerExceptionHandler)
 
             viewModel.modelRunner = modelRunner
-            viewModel.modelRunner.setDevice(ModelRunner.deviceFromString(device))
-            viewModel.modelRunner.setNumThreads(numThreads)
-            viewModel.modelRunner.setUse16Bit(use16Bit)
+            viewModel.modelRunner.setDevice_temp(ModelRunner.deviceFromString(device))
+            viewModel.modelRunner.setNumThreads_temp(numThreads)
+            viewModel.modelRunner.setUse16Bit_temp(use16Bit)
 
             model.load()
         } catch(e: Exception) {
@@ -338,9 +338,8 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 val selectedDevice = deviceOptions[position]
-                viewModel.modelRunner.setDevice(ModelRunner.deviceFromString(selectedDevice)) {
-                    prefs.edit(true) { putString(getString(R.string.prefs_run_on_device), selectedDevice) }
-                }
+                viewModel.modelRunner.setDevice_temp(ModelRunner.deviceFromString(selectedDevice))
+                prefs.edit(true) { putString(getString(R.string.prefs_run_on_device), selectedDevice) }
             }
         }
 
@@ -368,12 +367,12 @@ class MainActivity : AppCompatActivity() {
                 try {
                     val model = selectedBundle.newModel() as TIOTFLiteModel
 
-                    viewModel.modelRunner.switchModel(model) {
-                        prefs.edit(true) { putString(getString(R.string.prefs_selected_model), selectedModelId) }
-                        child<ModelRunnerWatcher>(R.id.container)?.let {
-                            it.modelDidChange()
-                            it.startRunning()
-                        }
+                    viewModel.modelRunner.switchModel(model)
+                    prefs.edit(true) { putString(getString(R.string.prefs_selected_model), selectedModelId) }
+
+                    child<ModelRunnerWatcher>(R.id.container)?.let {
+                        it.modelDidChange()
+                        it.startRunning()
                     }
                 } catch (e: Exception) {
                     AlertDialog.Builder(context).apply {
@@ -406,9 +405,8 @@ class MainActivity : AppCompatActivity() {
 
                 val selectedThreads = numThreadsOptions[position]
 
-                viewModel.modelRunner.setNumThreads(selectedThreads) {
-                    prefs.edit(true) { putInt(getString(R.string.prefs_num_threads), selectedThreads) }
-                }
+                viewModel.modelRunner.setNumThreads_temp(selectedThreads)
+                prefs.edit(true) { putInt(getString(R.string.prefs_num_threads), selectedThreads) }
             }
         }
 
@@ -422,9 +420,8 @@ class MainActivity : AppCompatActivity() {
                 return@setOnCheckedChangeListener
             }
 
-            viewModel.modelRunner.setUse16Bit(isChecked) {
-                prefs.edit(true) { putBoolean(getString(R.string.prefs_use_16_bit), isChecked) }
-            }
+            viewModel.modelRunner.setUse16Bit_temp(isChecked)
+            prefs.edit(true) { putBoolean(getString(R.string.prefs_use_16_bit), isChecked) }
         }
     }
 

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -345,7 +345,15 @@ class MainActivity : AppCompatActivity() {
 
                     child<ModelRunnerWatcher>(R.id.container)?.startRunning()
                 } catch (e: ModelRunner.ModelLoadingException) {
-                    // TODO: alert and rollback or do we even need to rollback?
+                    AlertDialog.Builder(context).apply {
+                        setTitle(R.string.modelrunner_exception_dialog_title)
+                        setMessage(R.string.modelrunner_exception_load_model)
+
+                        setPositiveButton("OK") { dialog, _ ->
+                            dialog.dismiss()
+                        }
+                    }.show()
+                    // TODO: rollback?
                 }
             }
         }
@@ -381,8 +389,8 @@ class MainActivity : AppCompatActivity() {
                     }
                 } catch (e: Exception) {
                     AlertDialog.Builder(context).apply {
-                        setTitle(R.string.unable_to_load_model_dialog_title)
-                        setMessage(R.string.unable_to_load_model_dialog_message)
+                        setTitle(R.string.modelrunner_exception_dialog_title)
+                        setMessage(R.string.modelrunner_exception_load_model)
 
                         setPositiveButton("OK") { dialog, _ ->
                             dialog.dismiss()
@@ -417,7 +425,15 @@ class MainActivity : AppCompatActivity() {
 
                     child<ModelRunnerWatcher>(R.id.container)?.startRunning()
                 } catch (e: ModelRunner.ModelLoadingException) {
-                 // TODO: alert and rollback
+                    AlertDialog.Builder(context).apply {
+                        setTitle(R.string.modelrunner_exception_dialog_title)
+                        setMessage(R.string.modelrunner_exception_load_model)
+
+                        setPositiveButton("OK") { dialog, _ ->
+                            dialog.dismiss()
+                        }
+                    }.show()
+                    // TODO: rollback?
                 }
             }
         }
@@ -439,7 +455,15 @@ class MainActivity : AppCompatActivity() {
 
                 child<ModelRunnerWatcher>(R.id.container)?.startRunning()
             } catch (e: ModelRunner.ModelLoadingException) {
-                // TODO: alert and rollback
+                AlertDialog.Builder(context).apply {
+                    setTitle(R.string.modelrunner_exception_dialog_title)
+                    setMessage(R.string.modelrunner_exception_load_model)
+
+                    setPositiveButton("OK") { dialog, _ ->
+                        dialog.dismiss()
+                    }
+                }.show()
+                // TODO: rollback?
             }
         }
     }

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -3,6 +3,7 @@ package ai.doc.netrunner
 import ai.doc.netrunner.view.*
 import ai.doc.netrunner.MainViewModel.Tab
 import ai.doc.netrunner.outputhandler.OutputHandlerManager
+import ai.doc.netrunner.utilities.DeviceUtilities
 
 import ai.doc.tensorio.TIOModel.TIOModelBundleManager
 import ai.doc.tensorio.TIOTFLiteModel.TIOTFLiteModel
@@ -17,7 +18,6 @@ import android.content.pm.ResolveInfo
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -57,10 +57,10 @@ class MainActivity : AppCompatActivity() {
 
     private val deviceOptions: ArrayList<String> by lazy {
         arrayListOf(getString(R.string.cpu), getString(R.string.gpu), getString(R.string.nnapi)).apply {
-            if (isEmulator || !viewModel.modelRunner.canRunOnGPU) {
+            if (DeviceUtilities.isEmulator || !viewModel.modelRunner.canRunOnGPU) {
                 remove(getString(R.string.gpu))
             }
-            if (isEmulator || !viewModel.modelRunner.canRunOnNnApi) {
+            if (DeviceUtilities.isEmulator || !viewModel.modelRunner.canRunOnNnApi) {
                 remove(getString(R.string.nnapi))
             }
         }
@@ -360,7 +360,6 @@ class MainActivity : AppCompatActivity() {
 
     private fun showImageResults(data: Intent?) {
         val image = data?.data ?: return
-
         val filePath = arrayOf(MediaStore.Images.Media.DATA)
 
         this.contentResolver.query(image, filePath, null, null, null)?.let {cursor ->
@@ -514,24 +513,6 @@ class MainActivity : AppCompatActivity() {
         around()
         child<ModelRunnerWatcher>(R.id.container)?.startRunning()
     }
-
-    private val isEmulator: Boolean
-        get() = (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")
-                || Build.FINGERPRINT.startsWith("generic")
-                || Build.FINGERPRINT.startsWith("unknown")
-                || Build.HARDWARE.contains("goldfish")
-                || Build.HARDWARE.contains("ranchu")
-                || Build.MODEL.contains("google_sdk")
-                || Build.MODEL.contains("Emulator")
-                || Build.MODEL.contains("Android SDK built for x86")
-                || Build.MANUFACTURER.contains("Genymotion")
-                || Build.PRODUCT.contains("sdk_google")
-                || Build.PRODUCT.contains("google_sdk")
-                || Build.PRODUCT.contains("sdk")
-                || Build.PRODUCT.contains("sdk_x86")
-                || Build.PRODUCT.contains("vbox86p")
-                || Build.PRODUCT.contains("emulator")
-                || Build.PRODUCT.contains("simulator"))
 
     //endregion
 }

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -337,9 +337,13 @@ class MainActivity : AppCompatActivity() {
                     return
                 }
                 try {
+                    child<ModelRunnerWatcher>(R.id.container)?.stopRunning()
+
                     val selectedDevice = deviceOptions[position]
                     viewModel.modelRunner.device = ModelRunner.deviceFromString(selectedDevice)
                     prefs.edit(true) { putString(getString(R.string.prefs_run_on_device), selectedDevice) }
+
+                    child<ModelRunnerWatcher>(R.id.container)?.startRunning()
                 } catch (e: ModelRunner.ModelLoadingException) {
                     // TODO: alert and rollback or do we even need to rollback?
                 }
@@ -361,14 +365,13 @@ class MainActivity : AppCompatActivity() {
                     modelSpinner.tag = null
                     return
                 }
-
-                val selectedModelId = viewModel.modelIds[position]
-                val selectedBundle = viewModel.manager.bundleWithId(selectedModelId)
-
-                child<ModelRunnerWatcher>(R.id.container)?.stopRunning()
-
                 try {
+                    child<ModelRunnerWatcher>(R.id.container)?.stopRunning()
+
+                    val selectedModelId = viewModel.modelIds[position]
+                    val selectedBundle = viewModel.manager.bundleWithId(selectedModelId)
                     val model = selectedBundle.newModel() as TIOTFLiteModel
+
                     viewModel.modelRunner.model = model
                     prefs.edit(true) { putString(getString(R.string.prefs_selected_model), selectedModelId) }
 
@@ -406,9 +409,13 @@ class MainActivity : AppCompatActivity() {
                     return
                 }
                 try {
+                    child<ModelRunnerWatcher>(R.id.container)?.stopRunning()
+
                     val selectedThreads = numThreadsOptions[position]
                     viewModel.modelRunner.numThreads = selectedThreads
                     prefs.edit(true) { putInt(getString(R.string.prefs_num_threads), selectedThreads) }
+
+                    child<ModelRunnerWatcher>(R.id.container)?.startRunning()
                 } catch (e: ModelRunner.ModelLoadingException) {
                  // TODO: alert and rollback
                 }
@@ -425,8 +432,12 @@ class MainActivity : AppCompatActivity() {
                 return@setOnCheckedChangeListener
             }
             try {
+                child<ModelRunnerWatcher>(R.id.container)?.stopRunning()
+
                 viewModel.modelRunner.use16Bit = isChecked
                 prefs.edit(true) { putBoolean(getString(R.string.prefs_use_16_bit), isChecked) }
+
+                child<ModelRunnerWatcher>(R.id.container)?.startRunning()
             } catch (e: ModelRunner.ModelLoadingException) {
                 // TODO: alert and rollback
             }

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -120,9 +120,9 @@ class MainActivity : AppCompatActivity() {
             val modelRunner = ModelRunner((model as TIOTFLiteModel), modelRunnerExceptionHandler)
 
             viewModel.modelRunner = modelRunner
-            viewModel.modelRunner.setDevice_temp(ModelRunner.deviceFromString(device))
-            viewModel.modelRunner.setNumThreads_temp(numThreads)
-            viewModel.modelRunner.setUse16Bit_temp(use16Bit)
+            viewModel.modelRunner.device = ModelRunner.deviceFromString(device)
+            viewModel.modelRunner.numThreads = numThreads
+            viewModel.modelRunner.use16Bit = use16Bit
 
             model.load()
         } catch(e: Exception) {
@@ -338,7 +338,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 val selectedDevice = deviceOptions[position]
-                viewModel.modelRunner.setDevice_temp(ModelRunner.deviceFromString(selectedDevice))
+                viewModel.modelRunner.device = ModelRunner.deviceFromString(selectedDevice)
                 prefs.edit(true) { putString(getString(R.string.prefs_run_on_device), selectedDevice) }
             }
         }
@@ -404,8 +404,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 val selectedThreads = numThreadsOptions[position]
-
-                viewModel.modelRunner.setNumThreads_temp(selectedThreads)
+                viewModel.modelRunner.numThreads = selectedThreads
                 prefs.edit(true) { putInt(getString(R.string.prefs_num_threads), selectedThreads) }
             }
         }
@@ -420,7 +419,7 @@ class MainActivity : AppCompatActivity() {
                 return@setOnCheckedChangeListener
             }
 
-            viewModel.modelRunner.setUse16Bit_temp(isChecked)
+            viewModel.modelRunner.use16Bit = isChecked
             prefs.edit(true) { putBoolean(getString(R.string.prefs_use_16_bit), isChecked) }
         }
     }

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -366,8 +366,7 @@ class MainActivity : AppCompatActivity() {
 
                 try {
                     val model = selectedBundle.newModel() as TIOTFLiteModel
-
-                    viewModel.modelRunner.switchModel(model)
+                    viewModel.modelRunner.model = model
                     prefs.edit(true) { putString(getString(R.string.prefs_selected_model), selectedModelId) }
 
                     child<ModelRunnerWatcher>(R.id.container)?.let {

--- a/app/src/main/java/ai/doc/netrunner/MainActivity.kt
+++ b/app/src/main/java/ai/doc/netrunner/MainActivity.kt
@@ -336,10 +336,13 @@ class MainActivity : AppCompatActivity() {
                     deviceSpinner.tag = null
                     return
                 }
-
-                val selectedDevice = deviceOptions[position]
-                viewModel.modelRunner.device = ModelRunner.deviceFromString(selectedDevice)
-                prefs.edit(true) { putString(getString(R.string.prefs_run_on_device), selectedDevice) }
+                try {
+                    val selectedDevice = deviceOptions[position]
+                    viewModel.modelRunner.device = ModelRunner.deviceFromString(selectedDevice)
+                    prefs.edit(true) { putString(getString(R.string.prefs_run_on_device), selectedDevice) }
+                } catch (e: ModelRunner.ModelLoadingException) {
+                    // TODO: alert and rollback or do we even need to rollback?
+                }
             }
         }
 
@@ -382,6 +385,7 @@ class MainActivity : AppCompatActivity() {
                             dialog.dismiss()
                         }
                     }.show()
+                    // TODO: rollback?
                 }
             }
         }
@@ -401,10 +405,13 @@ class MainActivity : AppCompatActivity() {
                     threadsSpinner.tag = null
                     return
                 }
-
-                val selectedThreads = numThreadsOptions[position]
-                viewModel.modelRunner.numThreads = selectedThreads
-                prefs.edit(true) { putInt(getString(R.string.prefs_num_threads), selectedThreads) }
+                try {
+                    val selectedThreads = numThreadsOptions[position]
+                    viewModel.modelRunner.numThreads = selectedThreads
+                    prefs.edit(true) { putInt(getString(R.string.prefs_num_threads), selectedThreads) }
+                } catch (e: ModelRunner.ModelLoadingException) {
+                 // TODO: alert and rollback
+                }
             }
         }
 
@@ -417,9 +424,12 @@ class MainActivity : AppCompatActivity() {
                 precisionSwitch.tag = null
                 return@setOnCheckedChangeListener
             }
-
-            viewModel.modelRunner.use16Bit = isChecked
-            prefs.edit(true) { putBoolean(getString(R.string.prefs_use_16_bit), isChecked) }
+            try {
+                viewModel.modelRunner.use16Bit = isChecked
+                prefs.edit(true) { putBoolean(getString(R.string.prefs_use_16_bit), isChecked) }
+            } catch (e: ModelRunner.ModelLoadingException) {
+                // TODO: alert and rollback
+            }
         }
     }
 

--- a/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
+++ b/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
@@ -58,6 +58,13 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
                 else -> Device.CPU
             }
         }
+        fun stringForevice(device: Device): String {
+            return when (device) {
+                Device.CPU -> "CPU"
+                Device.GPU -> "GPU"
+                Device.NNAPI -> "NNAPI"
+            }
+        }
     }
 
     val canRunOnGPU = GpuDelegateHelper.isGpuDelegateAvailable()
@@ -95,6 +102,7 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
                     }
 
                     value.load()
+
                     field = value
                     block.put(true)
                 } catch (e: Exception) {
@@ -162,6 +170,7 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
                     }
 
                     model.reload()
+
                     block.put(true)
                 } catch (e: Exception) {
                     block.put(false)

--- a/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
+++ b/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
@@ -21,10 +21,6 @@ private typealias Listener = (Map<String,Any>, Long) -> Unit
 
 private typealias BitmapProvider = () -> Bitmap?
 
-/** The model runner callback is called after any configuration change is completed on the runner's background thread */
-
-private typealias ModelRunnerCallback = () -> Unit
-
 /** Implemented by objects interested in changes to the model runner, but called by [MainActivity] */
 
 interface ModelRunnerWatcher {
@@ -131,42 +127,36 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
     var block = SynchronousQueue<Boolean>()
     // backgroundHandler.post(callback)
 
-    fun setNumThreads(value: Int, callback: ModelRunnerCallback? = null) {
+    fun setNumThreads_temp(value: Int) {
         backgroundHandler.post {
             numThreads = value
             block.put(true) // false if fails
         }
 
         val succeeded = block.take()
-
-        callback?.invoke()
     }
 
-    fun setUse16Bit(value: Boolean, callback: ModelRunnerCallback? = null) {
+    fun setUse16Bit_temp(value: Boolean) {
         backgroundHandler.post {
             use16Bit = value
             block.put(true) // false if fails
         }
 
         val succeeded = block.take()
-
-        callback?.invoke()
     }
 
-    fun setDevice(value: Device, callback: ModelRunnerCallback? = null) {
+    fun setDevice_temp(value: Device) {
         backgroundHandler.post {
             device = value
             block.put(true) // false if fails
         }
 
         val succeeded = block.take()
-
-        callback?.invoke()
     }
 
     /** Changes the model and uses current settings, falls back to previous model if fails */
 
-    fun switchModel(model: TIOTFLiteModel, callback: ModelRunnerCallback? = null) {
+    fun switchModel(model: TIOTFLiteModel) {
         // val previousModel = this.model
 
         fun doSwitch(model: TIOTFLiteModel) {
@@ -204,8 +194,6 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
         }
 
         val succeeded = block.take()
-
-        callback?.invoke()
     }
 
     //region Background Tasks
@@ -319,13 +307,12 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
 
     /** Waits for the background handler to finish processing before calling lambda */
 
-    fun wait(lambda: ()->Unit) {
+    fun waitOnRunner() {
         backgroundHandler.post {
             // lambda()
             block.put(true)
         }
 
         val succeeded = block.take()
-        lambda()
     }
 }

--- a/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
+++ b/app/src/main/java/ai/doc/netrunner/ModelRunner.kt
@@ -10,7 +10,6 @@ import android.os.HandlerThread
 import android.os.SystemClock
 import java.util.concurrent.SynchronousQueue
 
-private const val TAG = "ModelRunner"
 private const val HANDLE_THREAD_NAME = "ai.doc.netrunner.model-runner"
 
 /** A listener is called when a step of inference has completed */
@@ -58,7 +57,7 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
                 else -> Device.CPU
             }
         }
-        fun stringForevice(device: Device): String {
+        fun stringForDevice(device: Device): String {
             return when (device) {
                 Device.CPU -> "CPU"
                 Device.GPU -> "GPU"
@@ -104,8 +103,8 @@ class ModelRunner(model: TIOTFLiteModel, uncaughtExceptionHandler: Thread.Uncaug
                     }
 
                     value.load()
-
                     field = value
+
                     block.put(true)
                 } catch (e: Exception) {
                     block.put(false)

--- a/app/src/main/java/ai/doc/netrunner/utilities/DeviceUtilities.kt
+++ b/app/src/main/java/ai/doc/netrunner/utilities/DeviceUtilities.kt
@@ -1,0 +1,23 @@
+package ai.doc.netrunner.utilities
+
+import android.os.Build
+
+object DeviceUtilities {
+    val isEmulator: Boolean
+        get() = (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("unknown")
+                || Build.HARDWARE.contains("goldfish")
+                || Build.HARDWARE.contains("ranchu")
+                || Build.MODEL.contains("google_sdk")
+                || Build.MODEL.contains("Emulator")
+                || Build.MODEL.contains("Android SDK built for x86")
+                || Build.MANUFACTURER.contains("Genymotion")
+                || Build.PRODUCT.contains("sdk_google")
+                || Build.PRODUCT.contains("google_sdk")
+                || Build.PRODUCT.contains("sdk")
+                || Build.PRODUCT.contains("sdk_x86")
+                || Build.PRODUCT.contains("vbox86p")
+                || Build.PRODUCT.contains("emulator")
+                || Build.PRODUCT.contains("simulator"))
+}

--- a/app/src/main/java/ai/doc/netrunner/utilities/HandlerUtilities.kt
+++ b/app/src/main/java/ai/doc/netrunner/utilities/HandlerUtilities.kt
@@ -1,0 +1,4 @@
+package ai.doc.netrunner.utilities
+
+object HandlerUtilities {
+}

--- a/app/src/main/java/ai/doc/netrunner/utilities/HandlerUtilities.kt
+++ b/app/src/main/java/ai/doc/netrunner/utilities/HandlerUtilities.kt
@@ -1,4 +1,10 @@
 package ai.doc.netrunner.utilities
 
+import android.os.Handler
+import android.os.Looper
+
 object HandlerUtilities {
+    fun main(r: Runnable) {
+        Handler(Looper.getMainLooper()).post(r)
+    }
 }

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraFragment.kt
@@ -23,6 +23,8 @@ import java.util.*
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 
+// TODO: Migrate to CameraView (#53)
+
 open class LiveCameraFragment : Fragment(), OnRequestPermissionsResultCallback {
 
     /**

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
@@ -123,12 +123,6 @@ class LiveCameraTabFragment : LiveCameraFragment(), ModelRunnerWatcher /*, View.
     override fun modelDidChange() {
         viewModel.modelRunner.waitOnRunner()
         loadFragmentForModel(viewModel.modelRunner.model)
-
-//        viewModel.modelRunner.wait {
-//            Handler(Looper.getMainLooper()).post(Runnable {
-//                loadFragmentForModel(viewModel.modelRunner.model)
-//            })
-//        }
     }
 
     override fun stopRunning() {

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
@@ -121,11 +121,14 @@ class LiveCameraTabFragment : LiveCameraFragment(), ModelRunnerWatcher /*, View.
     /** Replaces the output handler but waits for the model runner to finish **/
 
     override fun modelDidChange() {
-        viewModel.modelRunner.wait {
-            Handler(Looper.getMainLooper()).post(Runnable {
-                loadFragmentForModel(viewModel.modelRunner.model)
-            })
-        }
+        viewModel.modelRunner.waitOnRunner()
+        loadFragmentForModel(viewModel.modelRunner.model)
+
+//        viewModel.modelRunner.wait {
+//            Handler(Looper.getMainLooper()).post(Runnable {
+//                loadFragmentForModel(viewModel.modelRunner.model)
+//            })
+//        }
     }
 
     override fun stopRunning() {

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
@@ -5,14 +5,13 @@ import ai.doc.netrunner.ModelRunnerWatcher
 import ai.doc.netrunner.R
 import ai.doc.netrunner.outputhandler.OutputHandler
 import ai.doc.netrunner.outputhandler.OutputHandlerManager
+import ai.doc.netrunner.utilities.HandlerUtilities
 import ai.doc.tensorio.TIOModel.TIOModel
 import android.content.Context
 import android.content.SharedPreferences
 import android.hardware.camera2.CameraCharacteristics
 
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.view.*
 import android.widget.TextView
 import androidx.core.content.edit
@@ -157,7 +156,7 @@ class LiveCameraTabFragment : LiveCameraFragment(), ModelRunnerWatcher /*, View.
 
     //endregion
 
-    /** Instructs the model runner to begin continuous classification of the model */
+    /** Instructs the model runner to run continuous inference with the model */
 
     private fun startContinuousInference() {
         if (isDetached || !isAdded) {
@@ -167,14 +166,14 @@ class LiveCameraTabFragment : LiveCameraFragment(), ModelRunnerWatcher /*, View.
         viewModel.modelRunner.startStreamingInference( {
             textureView.bitmap
         }, { output: Map<String,Any>, l: Long ->
-            Handler(Looper.getMainLooper()).post(Runnable {
+            HandlerUtilities.main(Runnable {
                 child<OutputHandler>(R.id.outputContainer)?.output = output
                 latencyTextView.text = "$l ms"
             })
         })
     }
 
-    /** Halts continuous classification of the model */
+    /** Halts continuous inference with the model */
 
     private fun stopContinuousInference() {
         viewModel.modelRunner.stopStreamingInference()
@@ -190,7 +189,7 @@ class LiveCameraTabFragment : LiveCameraFragment(), ModelRunnerWatcher /*, View.
         viewModel.modelRunner.runInferenceOnFrame( {
             textureView.bitmap
         }, { output: Map<String,Any>, l: Long ->
-            Handler(Looper.getMainLooper()).post(Runnable {
+            HandlerUtilities.main(Runnable {
                 child<OutputHandler>(R.id.outputContainer)?.output = null
                 child<OutputHandler>(R.id.outputContainer)?.output = output
                 latencyTextView.text = "$l ms"

--- a/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/LiveCameraTabFragment.kt
@@ -180,7 +180,7 @@ class LiveCameraTabFragment : LiveCameraFragment(), ModelRunnerWatcher /*, View.
         viewModel.modelRunner.stopStreamingInference()
     }
 
-    /** Runs a single frame of inference, used for exapmle when the camera is paused but the model changes */
+    /** Runs a single frame of inference, used for example when the camera is paused but the model changes */
 
     private fun runSingleFrameOfInference() {
         if (isDetached || !isAdded) {

--- a/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
@@ -5,12 +5,11 @@ import ai.doc.netrunner.ModelRunnerWatcher
 import ai.doc.netrunner.R
 import ai.doc.netrunner.outputhandler.OutputHandler
 import ai.doc.netrunner.outputhandler.OutputHandlerManager
+import ai.doc.netrunner.utilities.HandlerUtilities
 import ai.doc.tensorio.TIOModel.TIOModel
 
 import android.graphics.Bitmap
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -89,7 +88,7 @@ class SingleImageTabFragment : Fragment(), ModelRunnerWatcher {
         viewModel.modelRunner.runInferenceOnFrame( {
             bitmap
         }, { output: Map<String,Any>, l: Long ->
-            Handler(Looper.getMainLooper()).post(Runnable {
+            HandlerUtilities.main(Runnable {
                 child<OutputHandler>(R.id.outputContainer)?.output = output
                 latencyTextView.text = "$l ms"
             })

--- a/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
@@ -64,13 +64,6 @@ class SingleImageTabFragment : Fragment(), ModelRunnerWatcher {
     override fun modelDidChange() {
         viewModel.modelRunner.waitOnRunner()
         loadFragmentForModel(viewModel.modelRunner.model)
-
-//        viewModel.modelRunner.wait {
-//            Handler(Looper.getMainLooper()).post(Runnable {
-//                loadFragmentForModel(viewModel.modelRunner.model)
-//            })
-//        }
-
         viewModel.bitmap?.let {
             doBitmap(it)
         }

--- a/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
+++ b/app/src/main/java/ai/doc/netrunner/view/SingleImageTabFragment.kt
@@ -62,11 +62,15 @@ class SingleImageTabFragment : Fragment(), ModelRunnerWatcher {
     /** Replaces the output handler but waits for the model runner to finish  */
 
     override fun modelDidChange() {
-        viewModel.modelRunner.wait {
-            Handler(Looper.getMainLooper()).post(Runnable {
-                loadFragmentForModel(viewModel.modelRunner.model)
-            })
-        }
+        viewModel.modelRunner.waitOnRunner()
+        loadFragmentForModel(viewModel.modelRunner.model)
+
+//        viewModel.modelRunner.wait {
+//            Handler(Looper.getMainLooper()).post(Runnable {
+//                loadFragmentForModel(viewModel.modelRunner.model)
+//            })
+//        }
+
         viewModel.bitmap?.let {
             doBitmap(it)
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,13 +37,15 @@
     <string name="modelrunner_initfail_dialog_title">Unable to load model</string>
     <string name="modelrunner_initfail_dialog_message">There was a problem initializing the previous model, falling back to default model and settings</string>
 
-    <string name="modelrunner_exception_dialog_title">Unable to update settings</string>
+    <string name="modelrunner_model_exception_dialog_title">Unable to change model</string>
+    <string name="modelrunner_settings_exception_dialog_title">Unable to change setting</string>
     <string name="modelrunner_exception_run_inference_dialog_title">Unable to run the model</string>
     <string name="modelrunner_exception_unknown_dialog_title">"An unkown problem occurred"</string>
 
     <string name="modelrunner_exeption_gpu">GPU not supported in this build, falling back</string>
-    <string name="modelrunner_exception_run_inference">There was a problem executing inference with this model, falling back to default model and settings</string>
-    <string name="modelrunner_exception_load_model">This was a problem loading the model with these settings, falling back to previous model or settings"</string>
+    <string name="modelrunner_exception_run_inference">There was a problem executing inference with this model, try another one or change the model settings</string>
+    <string name="modelrunner_exception_change_model_message">This was a problem loading the model with the current settings, falling back to previous model"</string>
+    <string name="modelrunner_exception_change_settings_message">This was a problem loading the model with these settings, falling back to previous models"</string>
     <string name="modelrunner_exception_unknown">Net Runner encountered an unknown problem, falling back to previous model or settings"</string>
 
     <string name="camera_paused">Paused. Tap again to resume.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,22 +31,14 @@
 
     <string name="prefs_camera_facing">prefs.camera.facing</string>
 
-    <string name="unable_to_load_model_dialog_title">Unable to load model</string>
-    <string name="unable_to_load_model_dialog_message">There was a problem loading this model, please try another one</string>
-
     <string name="modelrunner_initfail_dialog_title">Unable to load model</string>
     <string name="modelrunner_initfail_dialog_message">There was a problem initializing the previous model, falling back to default model and settings</string>
 
     <string name="modelrunner_model_exception_dialog_title">Unable to change model</string>
     <string name="modelrunner_settings_exception_dialog_title">Unable to change setting</string>
     <string name="modelrunner_exception_run_inference_dialog_title">Unable to run the model</string>
-    <string name="modelrunner_exception_unknown_dialog_title">"An unkown problem occurred"</string>
 
-    <string name="modelrunner_exeption_gpu">GPU not supported in this build, falling back</string>
-    <string name="modelrunner_exception_run_inference">There was a problem executing inference with this model, try another one or change the model settings</string>
+    <string name="modelrunner_exception_run_inference_message">There was a problem executing inference with this model, try another one or change the model settings</string>
     <string name="modelrunner_exception_change_model_message">This was a problem loading the model with the current settings, falling back to previous model"</string>
     <string name="modelrunner_exception_change_settings_message">This was a problem loading the model with these settings, falling back to previous models"</string>
-    <string name="modelrunner_exception_unknown">Net Runner encountered an unknown problem, falling back to previous model or settings"</string>
-
-    <string name="camera_paused">Paused. Tap again to resume.</string>
 </resources>


### PR DESCRIPTION
The problem is we must load a model and execute inference on a model on the same thread. Technically this is only true for models using the GPU, but we support the GPU, so.

Using a SynchronousQueue in the ModelRunner to block any calling thread that changes model configuration while those changes are dispatched to the background thread. Looks like:

```kotlin
var numThreads = 1
  @Throws(ModelLoadingException::class) set(value) {
      backgroundHandler.post {
          try {
              model.numThreads = value
              model.reload()
              field = value
              block.put(true)
          } catch (e: Exception) {
              block.put(false)
          }
      }
      if (!block.take()) {
          throw ModelLoadingException()
      }
  }
```

The actual change is dispatched to the `backgroundHandler` and then `block.take()` is immediately hit. That function halts until a `block.put()` is executed, which is only done on the background thread after the config has completed. If the config changes fails, an exception is thrown and caught and the `block.put()` puts `false`. The call to `block.take()` returns the value that is put, so `false`, and throws a separate exception on the calling thread.

The SynchronousQueue effectively works like an implied `await` on calls to the model runner, and we get to rethrow exceptions from background threads on the main thread. The calling thread will almost alway be the main thread in response to UI interactions, and this will block the UI thread, but that's what we want since we're responding to a UI interaction, and the changes are usually fast, and we can handle exceptions on the main thread right away.

Code in the ModelRunner has gotten a little messier to manage all the `block.take` and `block.put` but all the code which uses the ModelRunner is much better.